### PR TITLE
Updating the version of jetty jar and dependencies to 9.4.12.v20180830

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,13 +90,13 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
-            <version>9.2.15.v20160210</version>
+            <version>9.4.12.v20180830</version>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.6.v20170531</version>
+            <version>9.4.12.v20180830</version>
         </dependency>
 
         <dependency>
@@ -108,21 +108,21 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
-            <version>9.4.6.v20170531</version>
+            <version>9.4.12.v20180830</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-util -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>9.4.6.v20170531</version>
+            <version>9.4.12.v20180830</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-io -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
-            <version>9.4.6.v20170531</version>
+            <version>9.4.12.v20180830</version>
         </dependency>
 
         <dependency>
@@ -170,7 +170,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.3.v20170317</version>
+            <version>9.4.12.v20180830</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Updating the version of jetty jar and dependencies to 9.4.12.v20180830